### PR TITLE
chore: clarify ai-review workflow is static rule-based

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,5 +1,11 @@
 name: AI Code Review
 
+# NOTE: This workflow performs STATIC RULE-BASED checks (pattern matching on diff),
+# NOT true AI semantic analysis. It detects common issues such as `any` usage,
+# empty catch blocks, missing test files, and exported symbol changes.
+# For AI-powered semantic review, the dev-mgr agent performs manual review
+# during patrol cycles using `gh pr diff` + LLM analysis.
+
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
Add comment at top of ai-review.yml clarifying this is static pattern matching, not true AI semantic analysis. Distinguishes from dev-mgr LLM patrol review.

Per dev-mgr review suggestion on PR #39.